### PR TITLE
feature: add asset bom to avoid mixing versions

### DIFF
--- a/asset-pipeline-bom/build.gradle
+++ b/asset-pipeline-bom/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'java-platform'
+}
+
+group = 'cloud.wondrify'
+
+javaPlatform {
+    allowDependencies()
+}
+
+dependencies {
+    constraints {
+        for (Project subproject : rootProject.subprojects) {
+            if (subproject.path == project.path || !(subproject.name in rootProject.ext.publishedProjects)) {
+                continue // ignore self
+            }
+
+            api project(":${subproject.path}")
+        }
+    }
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('gradle/publish-config.gradle')
+}

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,13 @@ allprojects {
     }
 }
 
+ext {
+    publishedProjects = []
+}
+
 subprojects { project ->
     if (project.name != 'asset-pipeline-classpath-test' && project.name != 'asset-pipeline-docs' && project.name != 'asset-pipeline-site') {
+        publishedProjects << project.name
         apply plugin: 'org.apache.grails.gradle.grails-publish'
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -45,6 +45,7 @@ repositories {
 dependencies {
     implementation platform("org.apache.grails:grails-gradle-bom:${gradleProperties.grailsVersion}")
     implementation 'org.apache.grails:grails-gradle-plugins'
+    implementation 'org.apache.grails.gradle:grails-publish'
     implementation 'com.gradle.publish:plugin-publish-plugin:1.3.1'
     implementation 'com.github.node-gradle:gradle-node-plugin:3.1.1'
 }

--- a/gradle/publish-config.gradle
+++ b/gradle/publish-config.gradle
@@ -1,4 +1,4 @@
-import org.grails.gradle.plugin.publishing.GrailsPublishExtension
+import org.apache.grails.gradle.publish.GrailsPublishExtension
 
 extensions.configure(GrailsPublishExtension) {
     // Explicit `it` is required here

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include(
+        'asset-pipeline-bom',
         'asset-pipeline-core',
         'asset-pipeline-gradle',
         'asset-pipeline-spring-boot',


### PR DESCRIPTION
This now produces a bom with the following pom file: 

         <?xml version="1.0" encoding="UTF-8"?>
         <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <!-- This module was also published with a richer model, Gradle metadata,  -->
           <!-- which should be used instead. Do not delete the following line which  -->
           <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
           <!-- that they should prefer consuming it instead. -->
           <!-- do_not_remove: published-with-gradle-metadata -->
           <modelVersion>4.0.0</modelVersion>
           <groupId>cloud.wondrify</groupId>
           <artifactId>asset-pipeline-bom</artifactId>
           <version>5.0.13-SNAPSHOT</version>
           <packaging>pom</packaging>
           <name>asset-pipeline-bom</name>
           <description>JVM Asset Pipeline</description>
           <url>https://github.com/wondrify/asset-pipeline</url>
           <licenses>
             <license>
               <name>The Apache Software License, Version 2.0</name>
               <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
               <distribution>repo</distribution>
             </license>
           </licenses>
           <developers>
             <developer>
               <id>davydotcom</id>
               <name>David Estes</name>
             </developer>
           </developers>
           <scm>
             <connection>scm:git@github.com:wondrify/asset-pipeline.git</connection>
             <developerConnection>scm:git@github.com:wondrify/asset-pipeline.git</developerConnection>
             <url>https://github.com/wondrify/asset-pipeline</url>
           </scm>
           <issueManagement>
             <system>GitHub Issues</system>
             <url>https://github.com/wondrify/asset-pipeline/issues</url>
           </issueManagement>
           <dependencyManagement>
             <dependencies>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>asset-pipeline-core</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>asset-pipeline-gradle</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>asset-pipeline-grails</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>asset-pipeline-servlet</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>asset-pipeline-spring-boot</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>coffee-asset-pipeline</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>ember-asset-pipeline</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>handlebars-asset-pipeline</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>jsx-asset-pipeline</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>less-asset-pipeline</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>sass-asset-pipeline</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
               <dependency>
                 <groupId>cloud.wondrify</groupId>
                 <artifactId>sass-dart-asset-pipeline</artifactId>
                 <version>5.0.13-SNAPSHOT</version>
               </dependency>
             </dependencies>
           </dependencyManagement>
         </project>
