### PR TITLE
remove: asset-pipeline-gradle from asset-pipeline-bom

### DIFF
--- a/asset-pipeline-bom/build.gradle
+++ b/asset-pipeline-bom/build.gradle
@@ -15,6 +15,10 @@ dependencies {
                 continue // ignore self
             }
 
+            if (subproject.name == 'asset-pipeline-gradle') {
+                continue // gradle dependencies are separate from build dependencies so do not include them in the bom
+            }
+
             api project(":${subproject.path}")
         }
     }


### PR DESCRIPTION
The bom is meant to be used for application classpaths, and not for gradle classpaths.  I think we should remove the gradle plugin as a result since we don't want gradle dependencies interfering since they're likely out of date compared to application dependencies.