### PR TITLE
Refactor asset compile task for improved property handling

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompilerWorker.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetCompilerWorker.groovy
@@ -29,7 +29,7 @@ import org.gradle.workers.WorkParameters
 @CompileStatic
 abstract class AssetCompilerWorker implements WorkAction<AssetCompilerWorker.Parameters> {
 
-    interface Parameters extends WorkParameters {
+    static interface Parameters extends WorkParameters {
         /**
          * Input directory containing assets to compile
          */

--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetForkedCompileTask.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetForkedCompileTask.groovy
@@ -19,13 +19,13 @@
 package asset.pipeline.gradle
 
 import groovy.json.JsonOutput
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.workers.WorkerExecutor
@@ -42,30 +42,35 @@ import javax.inject.Inject
 abstract class AssetForkedCompileTask extends AbstractCompile {
 
     @Nested
-    abstract final AssetPipelineExtension config
+    AssetPipelineExtension getConfig() {
+        return project.extensions.findByType(AssetPipelineExtension)
+    }
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    final ConfigurableFileCollection assetClassPath
+    abstract ConfigurableFileCollection getAssetClassPath()
 
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    final DirectoryProperty srcDir
+    abstract DirectoryProperty getInputDirectory()
+
+    @Internal
+    abstract ListProperty<String> getJarResolvers()
+
+    @Internal
+    abstract ListProperty<String> getAdditionalInputs()
 
     private WorkerExecutor workerExecutor
 
-    private File buildDir
-
     @Inject
     AssetForkedCompileTask(WorkerExecutor workerExecutor, ObjectFactory objectFactory) {
-        config = project.extensions.findByType(AssetPipelineExtension)
         this.workerExecutor = workerExecutor
-        srcDir = config.assetsPath
-        assetClassPath = objectFactory.fileCollection()
-        this.destinationDirectory.set(objectFactory.directoryProperty().convention(project.layout.buildDirectory.dir('assets')))
-        buildDir = project.layout.buildDirectory.asFile.get()
-    }
 
+        // Configure lazy properties - config will be resolved when accessed
+        def configExtension = project.extensions.findByType(AssetPipelineExtension)
+        inputDirectory.convention(configExtension.assetsPath)
+        this.destinationDirectory.set(objectFactory.directoryProperty().convention(project.layout.buildDirectory.dir('assets')))
+    }
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -82,13 +87,13 @@ abstract class AssetForkedCompileTask extends AbstractCompile {
     @Override
     void setSource(Object source) {
         if(Directory.isAssignableFrom(source.class)) {
-            this.srcDir.set(source as Directory)
+            this.inputDirectory.set(source as Directory)
         }
         else if(File.isAssignableFrom(source.class)) {
-            this.srcDir.set(source as File)
+            this.inputDirectory.set(source as File)
         }
         else if(DirectoryProperty.isAssignableFrom(source.class)) {
-            this.srcDir.set(source as DirectoryProperty)
+            this.inputDirectory.set(source as DirectoryProperty)
         }
         else {
             throw new RuntimeException("Unsupported source type: ${source.class.name}")
@@ -103,27 +108,28 @@ abstract class AssetForkedCompileTask extends AbstractCompile {
 
     protected void compile() {
         // Prepare worker parameters
-        def additionalInputs = []
-        def jarResolvers = []
+        List<String> additionalInputsList = []
+        List<String> jarResolversList = []
 
         // Collect additional input directories and jar resolvers
         config.resolvers.files.each { File resolverFile ->
             boolean isJarFile = resolverFile.exists() && resolverFile.file && resolverFile.name.endsWith('.jar')
             boolean isAssetFolder = resolverFile.exists() && resolverFile.directory
             if (isJarFile) {
-                jarResolvers.add(resolverFile.canonicalPath)
+                jarResolversList.add(resolverFile.canonicalPath)
             } else if (isAssetFolder) {
-                additionalInputs.add(resolverFile.canonicalPath)
+                additionalInputsList.add(resolverFile.canonicalPath)
             }
         }
 
         // Add classpath jars
-        this.assetClassPath?.files?.each { File jarFile ->
-            def isJarFile = jarFile.name.endsWith('.jar') || jarFile.name.endsWith('.zip')
-            if (jarFile.exists() && isJarFile) {
-                jarResolvers.add(jarFile.canonicalPath)
-            }
+        this.assetClassPath?.filter { File it -> it.name.endsWith('.jar') || it.name.endsWith('.zip') }?.each { File jarFile ->
+            jarResolversList.add(jarFile.canonicalPath)
         }
+
+        // Set the lazy properties
+        jarResolvers.set(jarResolversList)
+        additionalInputs.set(additionalInputsList)
 
         // Prepare configuration JSON
         String configurationJson = null
@@ -143,8 +149,8 @@ abstract class AssetForkedCompileTask extends AbstractCompile {
             configurationMap.put("includes", config.includes.getOrElse([]))
             configurationMap.put("resolvers", config.resolvers.files.collect { it.canonicalPath })
             configurationMap.put("assetsPath", config.assetsPath.get().asFile.canonicalPath)
-            configurationMap.put("cacheLocation",new File(buildDir, '.assetcache').canonicalPath)
-            String json = JsonOutput.toJson(configurationMap);
+            configurationMap.put("cacheLocation", new File(project.layout.buildDirectory.asFile.get(), '.assetcache').canonicalPath)
+            String json = JsonOutput.toJson(configurationMap)
             //base64 encoding the JSON to avoid issues with special characters in the command line
             configurationJson = json.bytes.encodeBase64().toString()
         }
@@ -155,38 +161,36 @@ abstract class AssetForkedCompileTask extends AbstractCompile {
             if (jvmArgs) {
                 workerExecutor.processIsolation { workerSpec ->
                     workerSpec.classpath.from(getClasspath())
-                    workerSpec.forkOptions { forkOptions ->
-                        forkOptions.jvmArgs(jvmArgs)
-                        forkOptions.maxHeapSize = config.forkOptions.memoryMaximumSize
-                        forkOptions.minHeapSize = config.forkOptions.memoryInitialSize
-                    }
+                    workerSpec.forkOptions.jvmArgs(jvmArgs as List<String>)
+                    workerSpec.forkOptions.maxHeapSize = config.forkOptions.memoryMaximumSize
+                    workerSpec.forkOptions.minHeapSize = config.forkOptions.memoryInitialSize
                 }.submit(AssetCompilerWorker) { parameters ->
-                    parameters.inputDirectory = srcDir.get().asFile.canonicalPath
+                    parameters.inputDirectory = inputDirectory.get().asFile.canonicalPath
                     parameters.outputDirectory = destinationDirectory.get().asFile.canonicalPath
                     parameters.configurationJson = configurationJson
-                    parameters.jarResolvers = jarResolvers as List<String>
-                    parameters.additionalInputs = additionalInputs as List<String>
+                    parameters.jarResolvers = jarResolvers.get()
+                    parameters.additionalInputs = additionalInputs.get()
                 }
             } else {
                 workerExecutor.classLoaderIsolation { workerSpec ->
                     workerSpec.classpath.from(getClasspath())
                 }.submit(AssetCompilerWorker) { parameters ->
-                    parameters.inputDirectory = srcDir.get().asFile.canonicalPath
+                    parameters.inputDirectory = inputDirectory.get().asFile.canonicalPath
                     parameters.outputDirectory = destinationDirectory.get().asFile.canonicalPath
                     parameters.configurationJson = configurationJson
-                    parameters.jarResolvers = jarResolvers as List<String>
-                    parameters.additionalInputs = additionalInputs as List<String>
+                    parameters.jarResolvers = jarResolvers.get()
+                    parameters.additionalInputs = additionalInputs.get()
                 }
             }
         } else {
             workerExecutor.classLoaderIsolation { workerSpec ->
                 workerSpec.classpath.from(getClasspath())
             }.submit(AssetCompilerWorker) { parameters ->
-                parameters.inputDirectory = srcDir.get().asFile.canonicalPath
+                parameters.inputDirectory = inputDirectory.get().asFile.canonicalPath
                 parameters.outputDirectory = destinationDirectory.get().asFile.canonicalPath
                 parameters.configurationJson = configurationJson
-                parameters.jarResolvers = jarResolvers as List<String>
-                parameters.additionalInputs = additionalInputs as List<String>
+                parameters.jarResolvers = jarResolvers.get()
+                parameters.additionalInputs = additionalInputs.get()
             }
         }
 


### PR DESCRIPTION
Refactored AssetForkedCompileTask to use abstract getter methods for Gradle properties and lazy configuration resolution. Updated handling of input directories, classpath, and resolver lists to improve compatibility with Gradle's configuration cache and property conventions. Also made Parameters interface static in AssetCompilerWorker.

Resolves failures from https://github.com/apache/grails-core/actions/runs/17865388330

Incorporates feedback from https://github.com/wondrify/asset-pipeline/pull/396