### PR TITLE
Remove temporary classpath jar creation in compile task

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetForkedCompileTask.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetForkedCompileTask.groovy
@@ -32,9 +32,6 @@ import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.process.ExecOperations
 import org.gradle.process.ExecResult
 import org.gradle.process.JavaExecSpec
-import java.util.jar.Attributes
-import java.util.jar.JarOutputStream
-import java.util.jar.Manifest
 import javax.inject.Inject
 
 /**
@@ -108,17 +105,13 @@ abstract class AssetForkedCompileTask extends AbstractCompile {
     }
 
     protected void compile() {
-        // Create a temporary classpath jar to avoid command line length issues on Windows
-        File classpathJar = createClasspathJar()
-
         ExecResult result = execOperations.javaexec(
                 new Action<JavaExecSpec>() {
                     @Override
                     @CompileDynamic
                     void execute(JavaExecSpec javaExecSpec) {
                         javaExecSpec.mainClass.set(getCompilerName())
-                        // Use the classpath jar instead of the full classpath
-                        javaExecSpec.setClasspath(project.files(classpathJar))
+                        javaExecSpec.setClasspath(getClasspath())
 
                         def jvmArgs = config.forkOptions?.jvmArgs
                         if (jvmArgs) {
@@ -128,6 +121,7 @@ abstract class AssetForkedCompileTask extends AbstractCompile {
                             javaExecSpec.setMaxHeapSize(config.forkOptions.memoryMaximumSize)
                             javaExecSpec.setMinHeapSize(config.forkOptions.memoryInitialSize)
                         }
+
 
                         List<String> arguments = [
                                 "-i",
@@ -142,31 +136,8 @@ abstract class AssetForkedCompileTask extends AbstractCompile {
 
                 }
         )
-
-        classpathJar.delete()
-
         result.assertNormalExitValue()
-    }
 
-    private File createClasspathJar() {
-        File tempDir = new File(project.layout.buildDirectory.asFile.get(), 'tmp/assetPipeline')
-        tempDir.mkdirs()
-        File classpathJar = new File(tempDir, 'classpath.jar')
-
-        String classPath = getClasspath().files.collect { file ->
-            // Convert to URI to handle spaces and special characters
-            file.toURI().toString()
-        }.join(' ')
-
-        Manifest manifest = new Manifest()
-        manifest.mainAttributes.put(Attributes.Name.MANIFEST_VERSION, '1.0')
-        manifest.mainAttributes.put(Attributes.Name.CLASS_PATH, classPath)
-
-        classpathJar.withOutputStream { fileOut ->
-            new JarOutputStream(fileOut, manifest).close()
-        }
-
-        return classpathJar
     }
 
     void prepareArguments(List<String> arguments) {


### PR DESCRIPTION
This was instead fixed in grails-gradle-plugins.
Refactors AssetForkedCompileTask to use the classpath directly instead of generating a temporary classpath jar. This simplifies the compile process and removes unnecessary file operations.