### PR TITLE
Update Grails to 7.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=5.0.20-SNAPSHOT
-grailsVersion=7.0.0-SNAPSHOT
+grailsVersion=7.0.0
 javaVersion=17
 bootstrapCssVersion=5.3.3
 closureCompilerVersion=v20240317


### PR DESCRIPTION
Grails 7.0.0-SNAPSHOT seems to be no longer available since the stable release