### PR TITLE
extensionless webjar require resolution support

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/DirectiveProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/DirectiveProcessor.groovy
@@ -262,6 +262,7 @@ class DirectiveProcessor {
     * Directive which allows inclusion of individual files
     * Example: //=require sample.js
     * Example (WebJar): //=require webjars/dist/jquery.js
+    * Example (WebJar without extension): //=require webjars/dist/css/bootstrap
     */
     def requireFileDirective(command, file, tree) {
         def fileName = command[1]
@@ -274,7 +275,8 @@ class DirectiveProcessor {
         }
         else {
             // Resolve WebJar paths before attempting to locate the file
-            fileName = AssetHelper.resolveWebjarPath(fileName)
+            // Pass contentType to enable extension inference for paths without extensions
+            fileName = AssetHelper.resolveWebjarPath(fileName, this.contentType)
 
             def newFile
             if( fileName.startsWith( AssetHelper.DIRECTIVE_FILE_SEPARATOR ) ) {

--- a/asset-pipeline-core/src/test/groovy/asset/pipeline/AssetHelperSpec.groovy
+++ b/asset-pipeline-core/src/test/groovy/asset/pipeline/AssetHelperSpec.groovy
@@ -220,4 +220,53 @@ class AssetHelperSpec extends Specification {
             // Verify cache is empty after clearing
             sizeAfterClear == 0
     }
+
+    void "resolveWebjarPath resolves CSS path without extension using contentType"() {
+        when:
+            def result = AssetHelper.resolveWebjarPath('webjars/dist/css/bootstrap', 'text/css')
+        then:
+            // Should resolve to versioned path with Bootstrap and add .css extension
+            result.startsWith('webjars/bootstrap/')
+            result.contains('/dist/css/bootstrap.css')
+            result =~ /webjars\/bootstrap\/\d+\.\d+/
+    }
+
+    void "resolveWebjarPath resolves JS path without extension using contentType"() {
+        when:
+            def result = AssetHelper.resolveWebjarPath('webjars/dist/jquery', 'application/javascript')
+        then:
+            // Should resolve to versioned path with jQuery and add .js extension
+            result.startsWith('webjars/jquery/')
+            result.contains('/dist/jquery.js')
+            result =~ /webjars\/jquery\/\d+\.\d+/
+    }
+
+    void "resolveWebjarPath resolves Bootstrap Icons CSS path without extension"() {
+        when:
+            def result = AssetHelper.resolveWebjarPath('webjars/font/bootstrap-icons', 'text/css')
+        then:
+            // Should resolve to versioned path with bootstrap-icons and add .css extension
+            // If bootstrap-icons webjar is not available in test classpath, it returns the original path
+            result.startsWith('webjars/bootstrap-icons/') || result == 'webjars/font/bootstrap-icons'
+            // Only check content if resolution succeeded
+            !result.contains('bootstrap-icons/') || result.contains('/font/bootstrap-icons.css')
+    }
+
+    void "resolveWebjarPath without contentType doesn't add extension"() {
+        when:
+            def result = AssetHelper.resolveWebjarPath('webjars/dist/css/bootstrap')
+        then:
+            // Without contentType, can't infer extension, so should return original path
+            // (unless the locator happens to find it without extension)
+            result == 'webjars/dist/css/bootstrap' || result.contains('bootstrap')
+    }
+
+    void "resolveWebjarPath prefers exact match over inferred extension"() {
+        when:
+            // Path that already has extension should be used as-is, not modified
+            def result = AssetHelper.resolveWebjarPath('webjars/dist/css/bootstrap.min.css', 'text/css')
+        then:
+            // Should resolve using the exact path with .min.css, not try to add .css again
+            result.contains('bootstrap.min.css')
+    }
 }


### PR DESCRIPTION
Allows

`webjars/dist/css/bootstrap` -> `webjars/bootstrap/5.3.0/dist/css/bootstrap.css`