### PR TITLE
Revert "update closure-compiler-unshaded to v20250820"

### DIFF
--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 
     // Needs to be compiled with Groovy 3 as it is used by the Gradle Plugin
     compileOnly "com.google.javascript:closure-compiler-unshaded:$closureCompilerVersion"
-    compileOnly "com.google.guava:guava:33.4.6-jre" // required for closure-compiler-unshaded - com.google.common.base.Predicate is missing otherwise
     compileOnly "org.codehaus.groovy:groovy:$groovy3Version"
     compileOnly "org.codehaus.groovy:groovy-json:$groovy3Version"
     compileOnly "org.codehaus.groovy:groovy-templates:$groovy3Version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ version=5.0.21-SNAPSHOT
 grailsVersion=7.0.0
 javaVersion=17
 bootstrapCssVersion=5.3.3
-closureCompilerVersion=v20250820
+closureCompilerVersion=v20240317
 fluentHcVersion=4.5.14
 graalvmVersion=24.1.2
 # Core and plugins are compiled with Groovy 3 as they are used by the Gradle Plugin


### PR DESCRIPTION
This reverts commit 46fd15a99f391956aa8b43f5709bec0870600598.

v20240317 is the last version compiled with Java 17.  All of the v2025 versions are compiled with Java 21.