### PR TITLE
Add `webjars-locator-core` to gradle plugin deps

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -208,13 +208,10 @@ The Asset Pipeline plugin provides automatic version resolution for WebJars, eli
 
 ### Setup
 
-To enable WebJar version resolution in Grails applications, add the webjars-locator-core dependency:
+Add your WebJar dependencies:
 
 ```groovy
 dependencies {
-    implementation "org.webjars:webjars-locator-core"
-
-    // Add your webjar dependencies
     implementation "org.webjars.npm:jquery:3.7.1"
     implementation "org.webjars.npm:bootstrap:5.3.0"
 }

--- a/asset-pipeline-core/build.gradle
+++ b/asset-pipeline-core/build.gradle
@@ -33,14 +33,14 @@ dependencies {
     compileOnly "org.codehaus.groovy:groovy-templates:$groovy3Version"
     compileOnly "org.graalvm.polyglot:polyglot:$graalvmVersion"
     compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
-    compileOnly "org.webjars:webjars-locator-core:0.59" // WebJar version resolution
+    compileOnly "org.webjars:webjars-locator-core:$webjarsLocatorCoreVersion" // WebJar version resolution
 
     testImplementation project(':asset-pipeline-classpath-test')
     testImplementation "org.apache.groovy:groovy:$groovy4Version"
     testImplementation "org.spockframework:spock-core:$spockVersion"
 
     // WebJar testing dependencies
-    testImplementation "org.webjars:webjars-locator-core:0.59"
+    testImplementation "org.webjars:webjars-locator-core:$webjarsLocatorCoreVersion"
     testImplementation "org.webjars.npm:jquery:3.7.1"
     testImplementation "org.webjars.npm:bootstrap:5.3.0"
 

--- a/asset-pipeline-gradle/build.gradle
+++ b/asset-pipeline-gradle/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     // and when running bootRun task (in development)
     runtimeOnly "com.google.javascript:closure-compiler-unshaded:$closureCompilerVersion"
     runtimeOnly "org.graalvm.js:js-community:$graalvmVersion"
+	runtimeOnly "org.webjars:webjars-locator-core:$webjarsLocatorCoreVersion"
 }
 
 task(console, dependsOn: 'classes', type: JavaExec) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ bootstrapCssVersion=5.3.3
 closureCompilerVersion=v20240317
 fluentHcVersion=4.5.14
 graalvmVersion=24.1.2
+webjarsLocatorCoreVersion=0.59
 # Core and plugins are compiled with Groovy 3 as they are used by the Gradle Plugin
 groovy3Version=3.0.23
 groovy4Version=4.0.25


### PR DESCRIPTION
This will make it available for Grails apps when running `bootRun`.