### PR TITLE
Resolve versionless webjar @import tags in sass files

### DIFF
--- a/sass-asset-pipeline/assets/stylesheets/webjar-import/webjarlocator.scss
+++ b/sass-asset-pipeline/assets/stylesheets/webjar-import/webjarlocator.scss
@@ -1,0 +1,1 @@
+@import "/webjars/scss/bootstrap";

--- a/sass-asset-pipeline/build.gradle
+++ b/sass-asset-pipeline/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation "org.apache.groovy:groovy:$groovy4Version"
     testImplementation "org.spockframework:spock-core:$spockVersion"
 
+    testRuntimeOnly "org.webjars:webjars-locator-core:$webjarsLocatorVersion"
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     testRuntimeOnly "org.webjars:bootstrap:$bootstrapCssVersion"
 }

--- a/sass-asset-pipeline/src/main/groovy/asset/pipeline/jsass/SassAssetFileImporter.groovy
+++ b/sass-asset-pipeline/src/main/groovy/asset/pipeline/jsass/SassAssetFileImporter.groovy
@@ -56,6 +56,7 @@ class SassAssetFileImporter implements Importer {
         
         for (String stylesheetPath : possibleStylesheets) {
             String standardPathStyle = stylesheetPath?.replaceAll(QUOTED_FILE_SEPARATOR, DIRECTIVE_FILE_SEPARATOR)
+            standardPathStyle = AssetHelper.resolveWebjarPath(standardPathStyle)
             def assetFile = AssetHelper.fileForFullName(standardPathStyle.toString())
             if (assetFile) {
                 log.debug "$parent imported $assetFile.path"

--- a/sass-asset-pipeline/src/test/groovy/asset/pipeline/jsass/SassProcessorSpec.groovy
+++ b/sass-asset-pipeline/src/test/groovy/asset/pipeline/jsass/SassProcessorSpec.groovy
@@ -107,4 +107,17 @@ class SassProcessorSpec extends Specification {
 		then:
 		output.contains('https://getbootstrap.com')
 	}
+
+	void "should compile versionless webjar imports"() {
+		given:
+		AssetPipelineConfigHolder.resolvers = []
+		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('test','assets'))
+		AssetPipelineConfigHolder.registerResolver(new ClasspathAssetResolver('classpath','META-INF/resources'))
+		def assetFile = AssetHelper.fileForFullName('webjar-import/webjarlocator.scss')
+		def processor = new SassProcessor()
+		when:
+		def output = processor.process(assetFile.inputStream.text,assetFile)
+		then:
+		output.contains('https://getbootstrap.com')
+	}
 }

--- a/sass-dart-asset-pipeline/assets/stylesheets/webjar-import/webjarlocator.scss
+++ b/sass-dart-asset-pipeline/assets/stylesheets/webjar-import/webjarlocator.scss
@@ -1,0 +1,1 @@
+@import "/webjars/scss/bootstrap";

--- a/sass-dart-asset-pipeline/build.gradle
+++ b/sass-dart-asset-pipeline/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation "org.apache.groovy:groovy:$groovy4Version"
     testImplementation "org.spockframework:spock-core:$spockVersion"
 
+    testRuntimeOnly "org.webjars:webjars-locator-core:$webjarsLocatorVersion"
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     testRuntimeOnly "org.webjars:bootstrap:$bootstrapCssVersion"
 }

--- a/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
+++ b/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
@@ -20,6 +20,7 @@ class SassAssetFileLoader {
     AssetFile baseFile
 
     Map<String, String> importMap = [:]
+    Map<String, String> resolvedPaths = [:]
 
     SassAssetFileLoader(AssetFile assetFile) {
         this.baseFile = assetFile
@@ -72,7 +73,7 @@ class SassAssetFileLoader {
      * @return
      */
     AssetFile getAssetFromScssImport(String parent, String importUrl) {
-        Path parentPath = importMap[parent] ? Paths.get(getAssetFromScssImport(importMap[parent], parent).path) : Paths.get(parent)
+        Path parentPath = importMap[parent] ? Paths.get(resolvedPaths[String.join("/",importMap[parent], parent)]) : Paths.get(parent)
 
         Path relativeRootPath = parentPath.parent ?: Paths.get('.')
         Path importUrlPath = Paths.get(importUrl)
@@ -91,6 +92,7 @@ class SassAssetFileLoader {
             standardPathStyle = AssetHelper.resolveWebjarPath(standardPathStyle)
             AssetFile assetFile = AssetHelper.fileForFullName(standardPathStyle.toString())
             if (assetFile) {
+                resolvedPaths[String.join("/", parent, importUrl)] = assetFile.path
                 log.debug "$parent imported $assetFile.path"
                 return assetFile
             }

--- a/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
+++ b/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
@@ -72,7 +72,8 @@ class SassAssetFileLoader {
      * @return
      */
     AssetFile getAssetFromScssImport(String parent, String importUrl) {
-        Path parentPath = Paths.get(parent)
+        Path parentPath = importMap[parent] ? Paths.get(getAssetFromScssImport(importMap[parent], parent).path) : Paths.get(parent)
+
         Path relativeRootPath = parentPath.parent ?: Paths.get('.')
         Path importUrlPath = Paths.get(importUrl)
 

--- a/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
+++ b/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
@@ -87,6 +87,7 @@ class SassAssetFileLoader {
 
         for (String stylesheetPath : possibleStylesheets) {
             String standardPathStyle = stylesheetPath?.replaceAll(QUOTED_FILE_SEPARATOR, DIRECTIVE_FILE_SEPARATOR)
+            standardPathStyle = AssetHelper.resolveWebjarPath(standardPathStyle)
             AssetFile assetFile = AssetHelper.fileForFullName(standardPathStyle.toString())
             if (assetFile) {
                 log.debug "$parent imported $assetFile.path"

--- a/sass-dart-asset-pipeline/src/test/groovy/asset/pipeline/dart/SassProcessorSpec.groovy
+++ b/sass-dart-asset-pipeline/src/test/groovy/asset/pipeline/dart/SassProcessorSpec.groovy
@@ -130,4 +130,17 @@ class SassProcessorSpec extends Specification {
 		then:
 		output.contains('https://getbootstrap.com')
 	}
+
+	void "should compile versionless webjar imports"() {
+		given:
+		AssetPipelineConfigHolder.resolvers = []
+		AssetPipelineConfigHolder.registerResolver(new FileSystemAssetResolver('test','assets'))
+		AssetPipelineConfigHolder.registerResolver(new ClasspathAssetResolver('classpath','META-INF/resources'))
+		def assetFile = AssetHelper.fileForFullName('webjar-import/webjarlocator.scss')
+		def processor = new SassProcessor()
+		when:
+		def output = processor.process(assetFile.inputStream.text,assetFile)
+		then:
+		output.contains('https://getbootstrap.com')
+	}
 }


### PR DESCRIPTION
This change allows imports of versionless webjar files in sass files.

Before: 

`@import "/webjars/bootstrap/5.3.3/scss/bootstrap";`

After:

`@import "/webjars/scss/bootstrap";`