### PR TITLE
Fix resource(file:) incorrectly routing non-asset paths through asset URL generation

### DIFF
--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetProcessorService.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetProcessorService.groovy
@@ -56,7 +56,7 @@ class AssetProcessorService implements GrailsApplicationAware {
 	String getAssetPath(final String path, final Map conf = grailsApplication.config.getProperty('grails.assets',Map,[:]), final boolean useManifest = true) {
 		final String relativePath = trimLeadingSlash(path)
 		if (useManifest) {
-			return resolveManifestProperty(relativePath)
+			return resolveManifestProperty(relativePath) ?: relativePath
 		} else {
 			return relativePath
 		}
@@ -209,9 +209,10 @@ class AssetProcessorService implements GrailsApplicationAware {
 						}
 					}
 				}
+				return result ?: path
 			}
-			return result ?: path
+			return result
 		}
-		return path
+		return null
 	}
 }


### PR DESCRIPTION
Any Grails plugin using resource(file:) for static resources in public/ directories is affected. For example, the grails-web-console plugin generates:                                                                                                                    
              
```gsp                                                                                                                         
  <link rel="stylesheet" href="${resource(file: 'console/vendor/font-awesome.css')}" />                                                
```                                                                                                          
  Expected: /console/vendor/font-awesome.css                                                                                           
  Actual: /assets/console/vendor/font-awesome.css (or CDN URL if configured)                                                           
                                                                                                                                       
  This results in:                                                                                                                     
  - 404 errors for users without CDN configuration                                                                                     
  - 403 errors for users with CDN configuration (files don't exist on CDN)                                                             
                                                                                                                                                                                                                                                             
  This fix:                                                                                                                            
  - Returns null for non-wildcard paths not in manifest (restores 5.0.22 behavior)                                                     
  - Preserves ?: path fallback for wildcard paths (maintains wildcard feature)                                                         
                                                                                                                                       
  Steps to Reproduce                                                                                                                   
                                                                                                                                       
  1. Use any Grails plugin that calls resource(file:) for static resources (e.g., grails-web-console)                                  
  2. Build and deploy the application (manifest.properties is created)                                                                 
  3. Access the plugin's page                                                                                                          
  4. Observe 404 errors for static resources 