### PR TITLE
fix race condition that multiproject builds can trigger on subsequent assetcompiles

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPluginPackage.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetPluginPackage.groovy
@@ -38,7 +38,8 @@ abstract class AssetPluginPackage extends DefaultTask {
     @TaskAction
     @CompileDynamic
     void compile() {
-        AssetPipelineConfigHolder.config = config.configOptions.get()
+        Map configOptions = config.configOptions.get()
+        AssetPipelineConfigHolder.config = new LinkedHashMap(configOptions)
 
         FileSystemAssetResolver fsResolver = new FileSystemAssetResolver('manifest', config.assetsPath.get().asFile.canonicalPath)
 


### PR DESCRIPTION
Subsequent runs of assetCompile will throw an exception related to config being an immutable map.  This is likely the cause, but we may want to consider forking the plugin package task too.