### PR TITLE
Grails 7 upgrade chores

### DIFF
--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -27,15 +27,15 @@ import org.springframework.util.ClassUtils
 
 @Slf4j
 class AssetPipelineGrailsPlugin extends Plugin {
-    def grailsVersion = '7.0.0-SNAPSHOT > *'
+    def grailsVersion = '7.0.0 > *'
     def title = 'Asset Pipeline Plugin'
     def author = 'David Estes'
     def description = 'The Asset-Pipeline is a plugin used for managing and processing static assets in Grails applications. Asset-Pipeline functions include processing and minification of both CSS and JavaScript files. It is also capable of being extended to compile custom static assets, such as CoffeeScript.'
-    def documentation = 'http://www.asset-pipeline.com'
+    def documentation = 'https://wondrify.github.io/asset-pipeline/'
     def license = 'APACHE'
-    def organization = [name: 'Bertram Capital', url: 'http://www.bertramcapital.com/']
-    def issueManagement = [system: 'GITHUB', url: 'http://github.com/wondrify/grails-asset-pipeline/issues']
-    def scm = [url: 'http://github.com/wondrify/grails-asset-pipeline']
+    def organization = [name: 'Bertram Capital', url: 'https://www.bertramcapital.com/']
+    def issueManagement = [system: 'GITHUB', url: 'https://github.com/wondrify/asset-pipeline/issues']
+    def scm = [url: 'https://github.com/wondrify/asset-pipeline']
     def pluginExcludes = [
             'grails-app/assets/**',
             'test/dummy/**'

--- a/i18n-asset-pipeline-grails/build.gradle
+++ b/i18n-asset-pipeline-grails/build.gradle
@@ -33,10 +33,9 @@ group = 'cloud.wondrify'
 apply plugin: 'groovy'
 apply plugin: 'java-library'
 apply plugin: "org.apache.grails.gradle.grails-plugin"
-apply plugin:"cloud.wondrify.asset-pipeline"
+apply plugin: "cloud.wondrify.asset-pipeline"
 
 ext {
-    
     pomDescription = 'asset-pipeline plugin to use localized messages in JavaScript.'
 }
 
@@ -58,7 +57,7 @@ dependencies {
 
     console 'org.apache.grails:grails-console'
 
-    profile 'org.grails.profiles:web-plugin:3.1.3'
+    profile 'org.apache.grails.profiles:web-plugin'
     testImplementation('org.apache.grails:grails-testing-support-web')
 }
 

--- a/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nAssetPipelineGrailsPlugin.groovy
+++ b/i18n-asset-pipeline-grails/src/main/groovy/asset/pipeline/i18n/I18nAssetPipelineGrailsPlugin.groovy
@@ -25,8 +25,7 @@ class I18nAssetPipelineGrailsPlugin extends Plugin {
 
     //-- Fields ---------------------------------
 
-    def version = '3.0.0'
-    def grailsVersion = '3.0.0 > *'
+    def grailsVersion = '7.0.0 > *'
     def profiles = ['web']
     def title = 'I18n Asset Pipeline Plugin'
     def author = 'Daniel Ellermann'


### PR DESCRIPTION
Grails 7 plugins are not backward compatible due to Spring Boot and Groovy major version upgrades and Java 17 as baseline.

Use https for urls

Grails profiles web: Use the org.apache.grails version