### PR TITLE
sass-dart: Add explicit null check to improve groovy 5 compatibility

### DIFF
--- a/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
+++ b/sass-dart-asset-pipeline/src/main/groovy/asset/pipeline/dart/SassAssetFileLoader.groovy
@@ -49,7 +49,7 @@ class SassAssetFileLoader {
             String priorParent = importMap[prev]
             if (priorParent && !prev.startsWith('/')) {
                 Path priorParentPath = Paths.get(priorParent)
-                if (priorParentPath.parent) {
+                if (priorParentPath.parent != null) {
                     prev = "${priorParentPath.parent.toString()}/${prev}"
                 }
             }


### PR DESCRIPTION
Since the `asBoolean` method for `Path` objects [has changed for Groovy 5](https://docs.groovy-lang.org/latest/html/groovy-jdk/java/nio/file/Path.html#asBoolean()), this change is necessary to make it behave the same way as it does with Groovy 3 and 4. Without this change, the parent path won't be resolved properly, which causes the file to be not found in the end (i.e. a NPE will be thrown).

Even though I don't think that Groovy 5 is currently officially supported by the asset-pipeline, this change will prevent buggy behavior as soon as Groovy 5 is supported.