### PR TITLE
Suppress JDK 24+ sun.misc.Unsafe warning in forked asset compiler

### DIFF
--- a/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetForkedCompileTask.groovy
+++ b/asset-pipeline-gradle/src/main/groovy/asset/pipeline/gradle/AssetForkedCompileTask.groovy
@@ -118,6 +118,16 @@ abstract class AssetForkedCompileTask extends AbstractCompile {
                         if (jvmArgs) {
                             javaExecSpec.jvmArgs(jvmArgs)
                         }
+                        // JDK 24+ warns on first use of sun.misc.Unsafe memory-access methods
+                        // (JEP 498). The forked compiler classpath includes protobuf — Closure
+                        // Compiler deserializes its runtime-library TypedASTs with it — and
+                        // protobuf's UnsafeUtil still probes Unsafe during class init
+                        // (protocolbuffers/protobuf#20760), so every fork prints the warning.
+                        // Suppress it unless the build author has set the flag explicitly.
+                        if (Runtime.version().feature() >= 24
+                                && !jvmArgs?.any { it.startsWith('--sun-misc-unsafe-memory-access') }) {
+                            javaExecSpec.jvmArgs('--sun-misc-unsafe-memory-access=allow')
+                        }
                         if(config.forkOptions) {
                             javaExecSpec.setMaxHeapSize(config.forkOptions.memoryMaximumSize)
                             javaExecSpec.setMinHeapSize(config.forkOptions.memoryInitialSize)


### PR DESCRIPTION
## Problem

On JDK 24+ every `assetCompile` run prints:

```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil (file:.../protobuf-java-x.y.z.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release
```

JEP 498 (JDK 24) warns by default on the first use of `sun.misc.Unsafe` memory-access methods, which were terminally deprecated by JEP 471 (JDK 23). `AssetForkedCompileTask` forks a fresh JVM per compile, so the once-per-process warning appears on **every build** — noisy DX that build authors can neither fix nor easily attribute.

## Cause (traced with `--sun-misc-unsafe-memory-access=debug`)

```
ClosureCompilerProcessor (minifyJs)
→ jscomp.Compiler stage-2 passes (ConvertTypesToColors)
→ Compiler.initRuntimeLibraryTypedAsts
→ TypedAstDeserializer.deserializeRuntimeLibraries   ← Closure's bundled runtime libs are protobuf blobs
→ protobuf CodedInputStream.readStringRequireUtf8
→ Utf8.<clinit> → UnsafeUtil.<clinit>
→ Unsafe.arrayBaseOffset                              ← flagged call
```

Closure Compiler deserializes its bundled runtime-library TypedASTs with protobuf, and protobuf's `UnsafeUtil` probes `Unsafe` during class initialization. Upstream tracking issue protocolbuffers/protobuf#20760 has been open since March 2025 with no milestone, so this is not going away on its own soon.

## Fix

Pass `--sun-misc-unsafe-memory-access=allow` to the forked compiler JVM when running on JDK 24+, unless the build author already set that flag via `assets.forkOptions.jvmArgs` (their `warn`/`debug`/`deny` choice wins).

- Version gate uses `Runtime.version().feature()` (plain JDK 10+ API, no dependency on newer Gradle `JavaVersion` constants). The gate is required: the flag is unrecognized before JDK 24 and would fail JVM startup. `javaexec` forks the daemon's own JVM (no executable override exists on `GroovyForkOptions`), so checking the current runtime is correct.
- Same approach Gradle itself takes with `-XX:+EnableDynamicAgentLoading` for test workers to suppress the analogous JDK 21 dynamic-agent warning.
- Becomes a harmless no-op once protobuf migrates to VarHandles.

Verified: compile passes, and a real-world `assetCompile` replay with the flag produces zero warnings with byte-identical output.