### PR TITLE
Contribute the asset filter as a bean definition

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,2 +1,2 @@
-java=21.0.10-librca
+java=21.0.12-librca
 gradle=8.14.4

--- a/asset-pipeline-grails/build.gradle
+++ b/asset-pipeline-grails/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     testImplementation 'org.apache.grails:grails-testing-support-web'
     testImplementation 'org.spockframework:spock-core'
 
+    // Lets AssetPipelineGrailsPluginSpec drive Spring's ahead-of-time processing, proving the bean
+    // definitions this plugin contributes can be turned into generated source for a native image.
+    testImplementation "org.springframework:spring-core-test:$springVersion"
+
     // WebJar testing dependencies
     testImplementation "org.webjars:webjars-locator-core:$webjarsLocatorVersion"
     testImplementation 'org.webjars.npm:jquery:3.7.1'       // specific version required by AssetsTagLibSpec

--- a/asset-pipeline-grails/build.gradle
+++ b/asset-pipeline-grails/build.gradle
@@ -21,6 +21,8 @@ grails {
     packageAssets = false
     springDependencyManagement = false
 
+    // Required for consumers building a GraalVM native image; see gradle/java-config.gradle.
+    indy = true
 }
 
 dependencies {

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineFilter.groovy
@@ -30,9 +30,21 @@ class AssetPipelineFilter extends OncePerRequestFilter {
 
 	@Override
 	void initFilterBean() throws ServletException {
-		final FilterConfig config = filterConfig
-		applicationContext = WebApplicationContextUtils.getWebApplicationContext(config.servletContext)
-		servletContext = config.servletContext
+		// GenericFilterBean implements InitializingBean, so when this filter is a container-managed
+		// bean (a nested bean definition of the FilterRegistrationBean) Spring calls this from
+		// afterPropertiesSet() - long before the servlet container supplies a FilterConfig.
+		// Resolve the ServletContext from whichever source is available and simply do nothing when
+		// neither is: init(FilterConfig) calls this method again once the container has started.
+		final FilterConfig config = getFilterConfig()
+		final ServletContext context = config != null ? config.servletContext : servletContext
+		if (context == null) {
+			return
+		}
+		servletContext = context
+		final ApplicationContext webApplicationContext = WebApplicationContextUtils.getWebApplicationContext(context)
+		if (webApplicationContext != null) {
+			applicationContext = webApplicationContext
+		}
 	}
 
 	@Override

--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/AssetPipelineGrailsPlugin.groovy
@@ -121,7 +121,12 @@ class AssetPipelineGrailsPlugin extends Plugin {
                     ClassUtils.forName("org.springframework.boot.context.embedded.FilterRegistrationBean", classLoader)
             assetPipelineFilter(registrationBean) {
                 order = GrailsFilters.ASSET_PIPELINE_FILTER.order
-                filter = new asset.pipeline.AssetPipelineFilter()
+                // Use a nested bean definition rather than a constructed instance. A bean
+                // definition is metadata, and Spring AOT turns it into generated Java source;
+                // there is no way to generate code that rebuilds an arbitrary pre-built object,
+                // so `new AssetPipelineFilter()` fails ahead-of-time processing with
+                // UnsupportedTypeValueCodeGenerationException.
+                filter = bean(AssetPipelineFilter)
                 if (!mapping) {
                     urlPatterns = ["/*".toString()]
                 } else {

--- a/asset-pipeline-grails/src/test/groovy/asset/pipeline/AssetPipelineGrailsPluginSpec.groovy
+++ b/asset-pipeline-grails/src/test/groovy/asset/pipeline/AssetPipelineGrailsPluginSpec.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package asset.pipeline
+
+import grails.core.DefaultGrailsApplication
+import grails.core.GrailsApplication
+import grails.spring.BeanBuilder
+import jakarta.servlet.Filter
+import org.grails.web.config.http.GrailsFilters
+import org.springframework.aot.test.generate.TestGenerationContext
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.aot.ApplicationContextAotGenerator
+import org.springframework.mock.web.MockFilterConfig
+import org.springframework.mock.web.MockServletContext
+import org.springframework.web.context.WebApplicationContext
+import org.springframework.web.context.support.GenericWebApplicationContext
+import spock.lang.Specification
+
+class AssetPipelineGrailsPluginSpec extends Specification {
+
+    MockServletContext servletContext
+    GenericWebApplicationContext applicationContext
+    GrailsApplication grailsApplication
+
+    void setup() {
+        servletContext = new MockServletContext()
+        applicationContext = new GenericWebApplicationContext(servletContext)
+        servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, applicationContext)
+        grailsApplication = new DefaultGrailsApplication()
+    }
+
+    void cleanup() {
+        applicationContext.close()
+        AssetPipelineConfigHolder.manifest = null
+        AssetPipelineConfigHolder.config = [:]
+    }
+
+    void 'the filter is contributed as a nested bean definition rather than a constructed instance'() {
+        when: 'the plugin contributes its bean definitions'
+        BeanDefinition registration = filterRegistrationDefinition()
+        Object filterValue = registration.propertyValues.getPropertyValue('filter').value
+
+        then: 'the filter is described by metadata, which Spring AOT is able to generate source for'
+        filterValue instanceof BeanDefinition
+        ((BeanDefinition) filterValue).beanClassName == AssetPipelineFilter.name
+
+        and: 'no pre-built filter instance is embedded in the definition'
+        !(filterValue instanceof Filter)
+
+        and: 'the rest of the registration is unchanged'
+        registration.propertyValues.getPropertyValue('order').value == GrailsFilters.ASSET_PIPELINE_FILTER.order
+        registration.propertyValues.getPropertyValue('urlPatterns').value == ['/assets/*']
+    }
+
+    void 'the container instantiates the filter and it still initialises when the servlet container starts it'() {
+        given: 'the filter registration contributed by the plugin'
+        BeanDefinition registration = filterRegistrationDefinition()
+
+        when: 'the container refreshes, running the full lifecycle of the nested filter bean'
+        applicationContext.registerBeanDefinition('assetPipelineFilter', registration)
+        applicationContext.refresh()
+        FilterRegistrationBean registrationBean = applicationContext.getBean('assetPipelineFilter', FilterRegistrationBean)
+
+        then: 'creating the bean succeeds, even though Spring calls initFilterBean() before any FilterConfig exists'
+        noExceptionThrown()
+        registrationBean.filter instanceof AssetPipelineFilter
+
+        when: 'the servlet container initialises the filter'
+        AssetPipelineFilter filter = registrationBean.filter as AssetPipelineFilter
+        filter.init(new MockFilterConfig(servletContext, 'assetPipelineFilter'))
+
+        then: 'it is wired to the servlet context and the web application context'
+        filter.servletContext.is(servletContext)
+        filter.applicationContext.is(applicationContext)
+    }
+
+    void 'the filter registration survives Spring ahead-of-time processing'() {
+        given: 'the filter registration contributed by the plugin'
+        applicationContext.registerBeanDefinition('assetPipelineFilter', filterRegistrationDefinition())
+
+        when: 'the definitions are processed ahead of time, as they are when building a native image'
+        new ApplicationContextAotGenerator().processAheadOfTime(applicationContext, new TestGenerationContext())
+
+        then: 'no value in the definition defeats code generation'
+        noExceptionThrown()
+    }
+
+    private BeanDefinition filterRegistrationDefinition() {
+        AssetPipelineGrailsPlugin plugin = new AssetPipelineGrailsPlugin()
+        plugin.grailsApplication = grailsApplication
+        plugin.applicationContext = applicationContext
+
+        Binding binding = new Binding()
+        binding.setVariable('application', grailsApplication)
+        binding.setVariable(GrailsApplication.APPLICATION_ID, grailsApplication)
+
+        BeanBuilder beanBuilder = new BeanBuilder(null, grailsApplication.classLoader)
+        beanBuilder.binding = binding
+
+        Closure beans = plugin.doWithSpring()
+        beans.delegate = beanBuilder
+        beanBuilder.beans(beans)
+
+        beanBuilder.getBeanDefinition('assetPipelineFilter')
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -23,36 +23,4 @@ subprojects { project ->
         publishedProjects << project.name
         apply plugin: 'org.apache.grails.gradle.grails-publish'
     }
-
-    // Compile every Groovy class with invokedynamic. Non-indy Groovy emits CallSiteArray
-    // dispatch, which defines call-site classes at runtime; GraalVM native-image forbids
-    // runtime class definition, so any non-indy class on the classpath is fatal there.
-    tasks.withType(GroovyCompile).configureEach {
-        groovyOptions.optimizationOptions.indy = true
-    }
-
-    // The Grails Gradle plugin drives groovyOptions.optimizationOptions.indy from its own
-    // `grails { indy = ... }` extension inside an afterEvaluate. Set it as soon as the
-    // plugin is applied, so the extension already says `true` by the time it is read.
-    ['org.apache.grails.gradle.grails-plugin',
-     'org.apache.grails.gradle.grails-web',
-     'org.apache.grails.gradle.grails-core'].each { String pluginId ->
-        pluginManager.withPlugin(pluginId) {
-            def grailsExt = project.extensions.findByName('grails')
-            if (grailsExt != null && grailsExt.hasProperty('indy')) {
-                grailsExt.indy = true
-            }
-        }
-    }
-}
-
-// Registering the configureEach action after every project has been evaluated guarantees it
-// runs last (task realization happens after all afterEvaluate callbacks), so nothing applied
-// by a third-party plugin can silently turn indy back off.
-gradle.projectsEvaluated {
-    subprojects.each { Project sub ->
-        sub.tasks.withType(GroovyCompile).configureEach {
-            groovyOptions.optimizationOptions.indy = true
-        }
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,4 +23,36 @@ subprojects { project ->
         publishedProjects << project.name
         apply plugin: 'org.apache.grails.gradle.grails-publish'
     }
+
+    // Compile every Groovy class with invokedynamic. Non-indy Groovy emits CallSiteArray
+    // dispatch, which defines call-site classes at runtime; GraalVM native-image forbids
+    // runtime class definition, so any non-indy class on the classpath is fatal there.
+    tasks.withType(GroovyCompile).configureEach {
+        groovyOptions.optimizationOptions.indy = true
+    }
+
+    // The Grails Gradle plugin drives groovyOptions.optimizationOptions.indy from its own
+    // `grails { indy = ... }` extension inside an afterEvaluate. Set it as soon as the
+    // plugin is applied, so the extension already says `true` by the time it is read.
+    ['org.apache.grails.gradle.grails-plugin',
+     'org.apache.grails.gradle.grails-web',
+     'org.apache.grails.gradle.grails-core'].each { String pluginId ->
+        pluginManager.withPlugin(pluginId) {
+            def grailsExt = project.extensions.findByName('grails')
+            if (grailsExt != null && grailsExt.hasProperty('indy')) {
+                grailsExt.indy = true
+            }
+        }
+    }
+}
+
+// Registering the configureEach action after every project has been evaluated guarantees it
+// runs last (task realization happens after all afterEvaluate callbacks), so nothing applied
+// by a third-party plugin can silently turn indy back off.
+gradle.projectsEvaluated {
+    subprojects.each { Project sub ->
+        sub.tasks.withType(GroovyCompile).configureEach {
+            groovyOptions.optimizationOptions.indy = true
+        }
+    }
 }

--- a/gradle/java-config.gradle
+++ b/gradle/java-config.gradle
@@ -1,5 +1,13 @@
 compileJava.options.release = javaVersion.toInteger()
 
+// Compile Groovy with invokedynamic. Non-indy Groovy emits CallSiteArray dispatch, which defines
+// call-site classes at runtime; GraalVM native-image forbids runtime class definition, so any
+// non-indy class on the classpath is fatal there. Grails plugin projects additionally need
+// `grails { indy = true }`, as the Grails Gradle plugin drives this from its own extension.
+tasks.withType(GroovyCompile).configureEach {
+    groovyOptions.optimizationOptions.indy = true
+}
+
 extensions.configure(JavaPluginExtension) {
     // Explicit `it` is required here
     it.withJavadocJar()

--- a/i18n-asset-pipeline-grails/build.gradle
+++ b/i18n-asset-pipeline-grails/build.gradle
@@ -39,6 +39,11 @@ ext {
     pomDescription = 'asset-pipeline plugin to use localized messages in JavaScript.'
 }
 
+grails {
+    // Required for consumers building a GraalVM native image; see gradle/java-config.gradle.
+    indy = true
+}
+
 
 dependencies {
     api 'org.springframework.boot:spring-boot-autoconfigure'


### PR DESCRIPTION
Lets an application using this plugin be processed ahead of time by Spring, and run as a GraalVM native image.

### The filter registration

The plugin handed `FilterRegistrationBean` an already-built filter:

```groovy
assetPipelineFilter(registrationBean) {
    filter = new asset.pipeline.AssetPipelineFilter()
}
```

Spring's ahead-of-time processing turns bean definitions into generated Java source, and there is no way to generate code that rebuilds an arbitrary pre-built object. `processAot` fails on it:

```
UnsupportedTypeValueCodeGenerationException: Failed to generate code for
'asset.pipeline.AssetPipelineFilter@...': unsupported value type AssetPipelineFilter
```

A nested bean definition is metadata the generator can express:

```groovy
filter = bean(AssetPipelineFilter)
```

### The filter's initialisation

Letting the container build the filter exposes a second problem. `GenericFilterBean` implements `InitializingBean`, so a container-managed filter has `initFilterBean()` called from `afterPropertiesSet()` — long before the servlet container supplies a `FilterConfig`. The old body dereferenced that config and threw an NPE at context startup.

It now takes the servlet context from whichever source is available and does nothing when neither is; `init(FilterConfig)` calls it again once the container starts.

### invokedynamic

Every Groovy subproject is now compiled with `indy`. Without it Groovy emits `CallSiteArray` dispatch, which defines a call-site class at run time, and a native image cannot define classes at all — one non-indy class on the classpath is fatal there.

The switch goes in `gradle/java-config.gradle`, the compile configuration each Groovy subproject already composes in:

```groovy
tasks.withType(GroovyCompile).configureEach {
    groovyOptions.optimizationOptions.indy = true
}
```

That is not sufficient on its own for a Grails plugin. `GrailsGradlePlugin` assigns `optimizationOptions.indy` from its own `grails { indy }` extension — which defaults to `false` — inside an `afterEvaluate`, so on those projects it overwrites the above. The two subprojects that are Grails plugins, `asset-pipeline-grails` and `i18n-asset-pipeline-grails`, go through the extension instead:

```groovy
grails {
    indy = true
}
```

The root build file is not involved.

### Limitations

- The `indy` change covers every Groovy subproject, not only the Grails one. That is deliberate — a native image needs the whole classpath compiled that way — but it is a wider change than the AOT fixes and worth reviewing on its own terms. (`asset-pipeline-bom` and `asset-pipeline-docs` are unaffected, having no Groovy to compile.)
- `spring-core-test` is added as a test dependency so the spec can drive `ApplicationContextAotGenerator` directly.
- Verified against Grails 8.0.0-SNAPSHOT with a GraalVM 25 native image: the filter is registered, assets are served, and `processAot` completes. Not verified against earlier Grails versions.
