### PR TITLE
Minify modern vendor bundles by default, and make the process.env shim optional

### DIFF
--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/ClosureCompilerProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/ClosureCompilerProcessor.groovy
@@ -147,6 +147,9 @@ class ClosureCompilerProcessor {
 				return LanguageMode.ECMASCRIPT5
 			case 'ES3':
 				return LanguageMode.ECMASCRIPT3
+			case 'ES2015':
+			case 'ES6':
+				return LanguageMode.ECMASCRIPT_2015
 			case 'ES2016':
 				return LanguageMode.ECMASCRIPT_2016
 			case 'ES2017':
@@ -159,10 +162,20 @@ class ClosureCompilerProcessor {
 				return LanguageMode.ECMASCRIPT_2020	
 			case 'ES2021':
 				return LanguageMode.ECMASCRIPT_2021
+			case 'STABLE':
+				return LanguageMode.STABLE
 			case 'UNSTABLE':
 				return LanguageMode.UNSTABLE
 			default:
-				return LanguageMode.ECMASCRIPT_2020
+				// STABLE tracks the newest language level this compiler fully supports.
+				// The old ECMASCRIPT_2020 default rejected syntax that has shipped in
+				// every browser for years — notably ES2022 public class fields, used by
+				// the stock UMD bundles of Chart.js, marked and friends. That forced
+				// every consuming app to keep a growing minifyOptions.excludes list just
+				// to get its vendor bundles through the pipeline. Parsing newer syntax is
+				// safe here: languageOut defaults to NO_TRANSPILE, so nothing that
+				// compiled before compiles differently now.
+				return LanguageMode.STABLE
 		}
 	}
 

--- a/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/JsNodeInjectProcessor.groovy
+++ b/asset-pipeline-core/src/main/groovy/asset/pipeline/processors/JsNodeInjectProcessor.groovy
@@ -37,10 +37,20 @@ class JsNodeInjectProcessor extends AbstractProcessor  {
 
 	String process(final String inputText, final AssetFile assetFile) {
 		String nodeEnv = 'development'
-		
-		if (AssetPipelineConfigHolder.config != null
-				&& AssetPipelineConfigHolder.config['nodeEnv'] != null) {
-			nodeEnv = AssetPipelineConfigHolder.config['nodeEnv']
+
+		final Object configuredEnv = AssetPipelineConfigHolder.config?.get('nodeEnv')
+
+		// `nodeEnv: false` opts out of the shim entirely. It exists so bundles that read
+		// process.env.NODE_ENV do not blow up in the browser, but it is prepended to every
+		// JS asset whether or not anything reads it — dead bytes for apps whose bundles
+		// never mention `process`. Set it the same way as `commonJs`: `configOptions` in
+		// the gradle `assets` block, or `grails.assets` config in a Grails application.
+		if (configuredEnv instanceof Boolean && !configuredEnv) {
+			return inputText
+		}
+
+		if (configuredEnv != null) {
+			nodeEnv = configuredEnv
 		}
 
 		// if(!assetFile.baseFile) {

--- a/asset-pipeline-core/src/test/groovy/asset/pipeline/processors/ClosureCompilerProcessorSpec.groovy
+++ b/asset-pipeline-core/src/test/groovy/asset/pipeline/processors/ClosureCompilerProcessorSpec.groovy
@@ -122,4 +122,56 @@ class ClosureCompilerProcessorSpec extends Specification {
         def ex = thrown(MinifyException)
         ex.message.contains("JSC_JS_MODULE_LOAD_WARNING")
     }
+
+    // ES2022 public class fields are common in modern production bundles
+    // (marked's and Chart.js's UMD builds both use them). Before ES2022 was a
+    // recognised languageMode the only ways to accept them were ECMASCRIPT_NEXT
+    // and UNSTABLE, so apps excluded such files from minification entirely.
+    static final String PUBLIC_CLASS_FIELD = "class TallyWidget { tally = 0; bump() { return ++this.tally; } }"
+
+    void "minifies ES2022 public class fields with no languageMode configured"() {
+        given:
+        def processor = new ClosureCompilerProcessor(compiler)
+        when:
+        // Regression guard: the default used to be ECMASCRIPT_2020, which rejected this
+        // outright and made every app exclude its vendor UMD bundles from minification.
+        def result = processor.process("test.js", PUBLIC_CLASS_FIELD, [:])
+        then:
+        noExceptionThrown()
+        result.contains("class")
+    }
+
+    void "explicit ES2020 still rejects ES2022 syntax"() {
+        given:
+        def processor = new ClosureCompilerProcessor(compiler)
+        when:
+        processor.process("test.js", PUBLIC_CLASS_FIELD, [languageMode: 'ES2020'])
+        then:
+        def ex = thrown(MinifyException)
+        ex.message.contains("JSC_LANGUAGE_FEATURE")
+    }
+
+    void "minifies ES2022 public class fields when languageMode is #mode"() {
+        given:
+        def processor = new ClosureCompilerProcessor(compiler)
+        when:
+        def result = processor.process("test.js", PUBLIC_CLASS_FIELD, [languageMode: mode])
+        then:
+        noExceptionThrown()
+        result.contains("class")
+        where:
+        mode << ['STABLE', 'UNSTABLE', 'ECMASCRIPT_NEXT']
+    }
+
+    void "maps ES2015 and its ES6 alias"() {
+        given:
+        def processor = new ClosureCompilerProcessor(compiler)
+        when:
+        def result = processor.process("test.js", "const f = (a) => a * 2;", [languageMode: mode])
+        then:
+        noExceptionThrown()
+        result
+        where:
+        mode << ['ES2015', 'ES6']
+    }
 }

--- a/asset-pipeline-core/src/test/groovy/asset/pipeline/processors/ClosureCompilerProcessorSpec.groovy
+++ b/asset-pipeline-core/src/test/groovy/asset/pipeline/processors/ClosureCompilerProcessorSpec.groovy
@@ -163,6 +163,40 @@ class ClosureCompilerProcessorSpec extends Specification {
         mode << ['STABLE', 'UNSTABLE', 'ECMASCRIPT_NEXT']
     }
 
+    // Raising the default languageIn only widens what can be PARSED — languageOut stays
+    // NO_TRANSPILE — so emitted output, and therefore browser compatibility, must be
+    // untouched for every source the previous ECMASCRIPT_2020 default already accepted.
+    static final Map PRE_ES2022_SOURCES = [
+        'es5'             : "function add(a,b){ return a+b; } var x = add(1,2);",
+        'es6 class/arrow' : "class A { constructor(){ this.v=1; } } const f = (x) => x*2; let g = `t${1}`;",
+        'es6 destructure' : "const {a,b} = obj; const [c,...d] = arr; function h(p=1,...r){ return p; }",
+        'es2017 async'    : "async function go(){ const r = await fetch('/x'); return r.json(); }",
+        'es2018 spread'   : "const merged = {...a, ...b}; async function w(it){ for await (const x of it) { use(x); } }",
+        'es2020 optional' : "const v = a?.b?.c ?? 'default'; const p = obj?.fn?.();",
+        'es2020 bigint'   : "const big = 9007199254740993n;",
+    ].asImmutable()
+
+    void "new default emits byte-identical output to the old ES2020 default: #name"() {
+        given:
+        def processor = new ClosureCompilerProcessor(compiler)
+        expect:
+        processor.process("test.js", src, [languageMode: 'ES2020']) == processor.process("test.js", src, [:])
+        where:
+        name << PRE_ES2022_SOURCES.keySet()
+        src  << PRE_ES2022_SOURCES.values()
+    }
+
+    void "explicit targetLanguage still transpiles down to ES5"() {
+        given:
+        def processor = new ClosureCompilerProcessor(compiler)
+        when:
+        def result = processor.process("test.js", PRE_ES2022_SOURCES['es6 class/arrow'], [targetLanguage: 'ES5'])
+        then:
+        noExceptionThrown()
+        !result.contains('=>')
+        !result.contains('class ')
+    }
+
     void "maps ES2015 and its ES6 alias"() {
         given:
         def processor = new ClosureCompilerProcessor(compiler)

--- a/asset-pipeline-core/src/test/groovy/asset/pipeline/processors/JsNodeInjectProcessorSpec.groovy
+++ b/asset-pipeline-core/src/test/groovy/asset/pipeline/processors/JsNodeInjectProcessorSpec.groovy
@@ -1,0 +1,42 @@
+package asset.pipeline.processors
+
+import asset.pipeline.AssetCompiler
+import asset.pipeline.AssetPipelineConfigHolder
+import spock.lang.Specification
+
+class JsNodeInjectProcessorSpec extends Specification {
+
+    def cleanup() {
+        AssetPipelineConfigHolder.config?.remove('nodeEnv')
+    }
+
+    void "injects the process shim by default"() {
+        given:
+        def processor = new JsNodeInjectProcessor(new AssetCompiler([:]))
+        when:
+        def result = processor.process("var a = 1;", null)
+        then:
+        result.startsWith('var process = process || {env: {NODE_ENV: "development"}};')
+    }
+
+    void "honours a configured nodeEnv value"() {
+        given:
+        AssetPipelineConfigHolder.config = (AssetPipelineConfigHolder.config ?: [:]) + [nodeEnv: 'production']
+        def processor = new JsNodeInjectProcessor(new AssetCompiler([:]))
+        when:
+        def result = processor.process("var a = 1;", null)
+        then:
+        result.startsWith('var process = process || {env: {NODE_ENV: "production"}};')
+    }
+
+    void "nodeEnv:false omits the shim entirely"() {
+        given:
+        AssetPipelineConfigHolder.config = (AssetPipelineConfigHolder.config ?: [:]) + [nodeEnv: false]
+        def processor = new JsNodeInjectProcessor(new AssetCompiler([:]))
+        when:
+        def result = processor.process("var a = 1;", null)
+        then:
+        result == "var a = 1;"
+        !result.contains('NODE_ENV')
+    }
+}


### PR DESCRIPTION
Two small changes to `asset-pipeline-core`, each with tests. They are independent — happy to split them into separate PRs if you would prefer.

## 1. Default the minifier to the compiler's current language level

`ClosureCompilerProcessor.evaluateLanguageMode` defaults to `ECMASCRIPT_2020` and has no mapping for anything newer, so any asset using syntax introduced after ES2020 fails to parse. ES2022 public class fields are the common case — the stock UMD bundles of Chart.js, marked and others all use them:

```
JSC_LANGUAGE_FEATURE. This language feature is only supported for
ECMASCRIPT_2022 mode or better: Public class fields.
```

The only escapes were `ECMASCRIPT_NEXT` and `UNSTABLE`, both broader than the problem warrants. In practice applications instead accumulate `minifyOptions.excludes` entries, one per vendor bundle, and keep adding to them as libraries modernise. The failure also surfaces only in a production asset compile, since development mode serves assets unminified — so it tends to be found late.

This defaults to `STABLE`, the newest level the bundled compiler fully supports, and adds the missing `STABLE` and `ES2015` (`ES6`) mappings.

`ECMASCRIPT_2022` is deliberately **not** mapped — the compiler rejects it as a parser input mode with `IllegalStateException: Unexpected language mode: ECMASCRIPT_2022`. It looks like the obvious value to add, so the omission is intentional.

### This does not affect browser compatibility

Worth stating explicitly, since "raise the language level" sounds like it should ship newer syntax to browsers. It does not.

`languageIn` controls what can be **parsed**; `languageOut` controls what is **emitted**. Only `languageIn` changes here, and `languageOut` still defaults to `NO_TRANSPILE`, so output syntax always equals input syntax. The old `ECMASCRIPT_2020` default was acting purely as a parse gate — it was never providing downlevel output.

There is now a test asserting output is byte-identical under the old and new defaults, across every level the old default accepted:

| input | old `ES2020` default vs new `STABLE` default |
|---|---|
| ES5 | identical |
| ES6 class / arrow / template literal | identical |
| ES6 destructuring / rest / default params | identical |
| ES2017 async-await | identical |
| ES2018 object spread / `for await` | identical |
| ES2020 optional chaining / `??` | identical |
| ES2020 BigInt | identical |

The only files whose behaviour changes are ones that previously **failed the build**. And those were not protected before either: the `excludes` workaround still served the file to browsers, just unminified — same syntax, same support matrix.

Applications that want the old strictness, or genuinely want downlevel output, are unaffected:

```groovy
assets {
    minifyOptions = [languageMode: 'ES2020']   // parse strictly, as before
    // or
    minifyOptions = [targetLanguage: 'ES5']    // actually transpile down
}
```

Both are covered by tests, including one asserting `targetLanguage: 'ES5'` still strips arrows and classes.

## 2. Allow opting out of the `process.env` shim

`JsNodeInjectProcessor` prepends this to **every** JavaScript asset:

```js
var process = process || {env: {NODE_ENV: "development"}};
```

It exists so bundles that read `process.env.NODE_ENV` do not fail in the browser, but the existing `nodeEnv` option only changes the value — never whether the line is emitted at all. Applications whose bundles never reference `process` pay for it on every JS file.

This treats a boolean `false` as an opt-out. It is set the same way as the existing `commonJs` flag — `configOptions` in the gradle `assets` block:

```groovy
assets {
    configOptions = [nodeEnv: false]
}
```

or via `grails.assets` config in a Grails application:

```yaml
grails:
    assets:
        nodeEnv: false
```

Any other value keeps its current meaning, so default behaviour is unchanged.

## Verification

- `:asset-pipeline-core:test` — all pass, including new tests for the output-equivalence table above, the `targetLanguage` escape hatch, explicit-`ES2020` rejection of ES2022 syntax, `STABLE`/`UNSTABLE`/`ECMASCRIPT_NEXT`, the `ES2015`/`ES6` aliases, and all three `nodeEnv` states.
- Checked against the real marked 18.0.9 UMD bundle: fails under the previous default, minifies under the new one, and the output still parses markdown correctly — including option handling such as `breaks: true`, which is where a careless fix (`optimizationLevel: 'ADVANCED'`) silently regresses.
- Built into a Grails 8 application and ran `assetCompile` with `minifyOptions.excludes` emptied: succeeds with no Closure errors, and `marked.umd.js`, `chart.umd.js` and `quill.js` all compile and remain functional.
- Ran the same application with `configOptions = [nodeEnv: false]`: the shim is absent from all 34 compiled JS files, and assets still compile and run.