### PR TITLE
Order against the Grails url mappings by name

### DIFF
--- a/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetPipelineAutoConfiguration.java
+++ b/asset-pipeline-grails/src/main/groovy/asset/pipeline/grails/AssetPipelineAutoConfiguration.java
@@ -4,14 +4,15 @@ import grails.config.Settings;
 import grails.util.Environment;
 import grails.web.mapping.LinkGenerator;
 import groovy.transform.CompileStatic;
-import org.grails.plugins.web.mapping.UrlMappingsAutoConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 
 @CompileStatic
-@AutoConfiguration(before = { UrlMappingsAutoConfiguration.class })
+// Named rather than referenced by class: grails-url-mappings, which carries it, is absent from a
+// Spring Boot application that uses this plugin's tag libraries without the rest of Grails.
+@AutoConfiguration(beforeName = "org.grails.plugins.web.mapping.UrlMappingsAutoConfiguration")
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 class AssetPipelineAutoConfiguration {
     @Value("${" + Settings.WEB_LINK_GENERATOR_USE_CACHE + ":#{null}}")

--- a/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetPipelineAutoConfigurationSpec.groovy
+++ b/asset-pipeline-grails/src/test/groovy/asset/pipeline/grails/AssetPipelineAutoConfigurationSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package asset.pipeline.grails
+
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import spock.lang.Specification
+
+class AssetPipelineAutoConfigurationSpec extends Specification {
+
+    private static final String URL_MAPPINGS_AUTO_CONFIGURATION =
+            'org.grails.plugins.web.mapping.UrlMappingsAutoConfiguration'
+
+    void 'the auto-configuration is read where the Grails url mappings are absent'() {
+        given: 'a Spring Boot application using the tag libraries without the rest of Grails, which brings no grails-url-mappings'
+        ClassLoader classLoader = withoutUrlMappings()
+        Class<?> autoConfigurationClass = classLoader.loadClass(AssetPipelineAutoConfiguration.name)
+
+        when: 'Spring reads the annotation to order the auto-configurations'
+        def annotation = autoConfigurationClass.getAnnotation(classLoader.loadClass(AutoConfiguration.name))
+        annotation.before()
+
+        then: 'nothing has to be loaded to read it'
+        noExceptionThrown()
+    }
+
+    void 'the Grails url mappings auto-configuration is still ordered against'() {
+        expect:
+        AssetPipelineAutoConfiguration.getAnnotation(AutoConfiguration).beforeName() ==
+                [URL_MAPPINGS_AUTO_CONFIGURATION] as String[]
+    }
+
+    private static ClassLoader withoutUrlMappings() {
+        URL[] classPath = System.getProperty('java.class.path')
+                .split(File.pathSeparator)
+                .collect { new File(it).toURI().toURL() } as URL[]
+        new URLClassLoader(classPath, ClassLoader.platformClassLoader) {
+
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name == URL_MAPPINGS_AUTO_CONFIGURATION) {
+                    throw new ClassNotFoundException(name)
+                }
+                return super.loadClass(name, resolve)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Lets a Spring Boot application use this plugin's tag libraries without the rest of Grails.

`@AutoConfiguration(before = { UrlMappingsAutoConfiguration.class })` names a class carried by
grails-url-mappings, and a class literal in an annotation has to be loaded when Spring reads it.
An application that has the tag libraries but not the Grails plugin machinery logs this on every
startup, and the ordering is dropped:

```
WARN o.s.core.annotation.MergedAnnotation : Failed to introspect meta-annotation @AutoConfiguration
on class asset.pipeline.grails.AssetPipelineAutoConfiguration:
java.lang.TypeNotPresentException: Type org.grails.plugins.web.mapping.UrlMappingsAutoConfiguration not present
```

`beforeName` takes the same class as a string, so nothing is loaded to read the annotation and the
ordering still applies wherever the class is there.
