### PR TITLE
Wire the asset pipeline for a Spring Boot application

### DIFF
--- a/asset-pipeline-spring-boot/Readme.markdown
+++ b/asset-pipeline-spring-boot/Readme.markdown
@@ -6,14 +6,13 @@ This is a preliminary test project for adding support to spring boot.
 It takes files stored in `assets/javascripts` , `assets/stylesheets`, `assets/images`, `assets/**/*`, and compiles them into the root jar `assets` folder.
 It supports both development mode where it compiles on the fly and production `gradle assemble`
 
-Note: Be Sure to add to your `@ComponentScan` annotation the class path `asset.pipeline.springboot`
+The library configures itself: a servlet application that has it on the class path serves what
+the pipeline compiled from `/assets/*`, without anything to wire up.
 
 ```groovy
 package demo
 
-@Configuration
-@ComponentScan(['demo','asset.pipeline.springboot'])
-@EnableAutoConfiguration
+@SpringBootApplication
 class Application {
 
     static void main(String[] args) {
@@ -22,6 +21,19 @@ class Application {
 }
 
 ```
+
+An application that declares its own `assetPipelineFilterBean` keeps it, and one that wants the
+library on the class path without the filter says so:
+
+```yaml
+assets:
+    enabled: false
+```
+
+An older application that added `asset.pipeline.springboot` to its `@ComponentScan` needs no
+change: the scan registers the configuration, the auto-configuration sees the bean it defines
+and stands aside, and the same `assets.enabled` setting still switches it off. The scan entry is
+redundant rather than inert - remove it and the auto-configuration does the same work.
 
 Example Gradle File for Spring Boot:
 ```groovy

--- a/asset-pipeline-spring-boot/build.gradle
+++ b/asset-pipeline-spring-boot/build.gradle
@@ -30,9 +30,32 @@ dependencies {
 	implementation "org.springframework:spring-core:$springVersion"
 	implementation "org.springframework:spring-web:$springVersion"
 	implementation "org.springframework.boot:spring-boot:$springBootVersion"
+	implementation "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
 
 	compileOnly "org.apache.groovy:groovy:$groovy5Version"
 	compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
+
+	// Spring Boot manages its own test stack, and Spock comes from its bom as it does elsewhere here.
+	testImplementation platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion")
+	testImplementation platform("org.spockframework:spock-bom:$spock5Version")
+
+	testImplementation "org.apache.groovy:groovy:$groovy5Version"
+	testImplementation 'org.spockframework:spock-core'
+	testImplementation 'org.springframework.boot:spring-boot-test'
+	// Spring Boot's context runner hands the test an AssertJ-backed context, so AssertJ is on the
+	// test path whether or not a test asserts with it.
+	testImplementation 'org.assertj:assertj-core'
+	testImplementation "jakarta.servlet:jakarta.servlet-api:$servletApiVersion"
+	testImplementation "org.slf4j:slf4j-api:$slf4jVersion" // @Slf4j on AssetPipelineService needs it at run time
+	testRuntimeOnly "org.slf4j:slf4j-nop:$slf4jVersion"
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher' // required by Gradle 9
+}
+
+tasks.withType(Test).configureEach {
+	useJUnitPlatform()
+	testLogging {
+		events('passed', 'skipped', 'failed')
+	}
 }
 
 tasks.register('console', JavaExec) {

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineAutoConfiguration.java
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package asset.pipeline.springboot;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Serves what the pipeline compiled, in a Spring Boot application that adds this library. The
+ * manifest an application ships is read where it is, and the filter serves the digest-named files
+ * beside it; an application built without one gets the development filter, which compiles an asset
+ * as it is asked for.
+ *
+ * <p>An application that declares {@link AssetPipelineService} itself keeps its own, and one that
+ * has this library on its class path without wanting the filter sets {@code assets.enabled} to
+ * {@code false}.
+ */
+@AutoConfiguration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnProperty(name = AssetPipelineAutoConfiguration.ENABLED, matchIfMissing = true)
+@ConditionalOnMissingBean(name = AssetPipelineAutoConfiguration.FILTER_BEAN_NAME)
+@Import(AssetPipelineService.class)
+public class AssetPipelineAutoConfiguration {
+
+    static final String FILTER_BEAN_NAME = "assetPipelineFilterBean";
+
+    /** Named for {@code assets.mapping}, which the Micronaut adapter already reads. */
+    static final String ENABLED = "assets.enabled";
+
+}

--- a/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineService.groovy
+++ b/asset-pipeline-spring-boot/src/main/groovy/asset/pipeline/springboot/AssetPipelineService.groovy
@@ -4,26 +4,35 @@ import asset.pipeline.AssetPipelineConfigHolder
 import asset.pipeline.fs.ClasspathAssetResolver
 import asset.pipeline.fs.FileSystemAssetResolver
 import groovy.util.logging.Slf4j
-import jakarta.servlet.ServletContext
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.context.WebApplicationContext
-import org.springframework.web.context.support.WebApplicationContextUtils
+import org.springframework.context.ApplicationContext
 
+/**
+ * The condition is here rather than only on the auto-configuration because this is what defines
+ * the filter: an application that still names this package in its component scan registers this
+ * class itself, and would otherwise get a filter it had switched off.
+ */
 @Slf4j
 @Configuration
+@ConditionalOnProperty(name = AssetPipelineAutoConfiguration.ENABLED, matchIfMissing = true)
 class AssetPipelineService {
 
+	// The context itself, rather than the one the servlet context holds: it is the same context,
+	// and it is there before a servlet container is. Asked for as an ApplicationContext rather than
+	// as the ResourceLoader it also is, because a field of that name would be satisfied by an
+	// application's own bean called resourceLoader, which resolves paths against the class path
+	// instead of the servlet context.
 	@Autowired
-	ServletContext servletContext;
+	ApplicationContext applicationContext
 
 	@Bean
 	public FilterRegistrationBean assetPipelineFilterBean() {
 		def manifestProps = new Properties()
 
-		WebApplicationContext applicationContext = WebApplicationContextUtils.getWebApplicationContext(servletContext)
 		def manifestFile = applicationContext.getResource("classpath:assets/manifest.properties")
 		if(!manifestFile.exists()) {
 			manifestFile = applicationContext.getResource("assets/manifest.properties")

--- a/asset-pipeline-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/asset-pipeline-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+asset.pipeline.springboot.AssetPipelineAutoConfiguration

--- a/asset-pipeline-spring-boot/src/test/groovy/asset/pipeline/springboot/AssetPipelineAutoConfigurationSpec.groovy
+++ b/asset-pipeline-spring-boot/src/test/groovy/asset/pipeline/springboot/AssetPipelineAutoConfigurationSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package asset.pipeline.springboot
+
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner
+import spock.lang.Specification
+
+/**
+ * What serves the compiled assets in a Spring Boot application that adds this library.
+ */
+class AssetPipelineAutoConfigurationSpec extends Specification {
+
+    void 'the auto-configuration is one Spring Boot will find'() {
+        given: 'the tests above import the class themselves, so none of them would notice its absence here'
+        String imports = getClass().getResourceAsStream(
+                '/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports').text
+
+        expect:
+        imports.readLines()*.trim().contains(AssetPipelineAutoConfiguration.name)
+    }
+
+    private WebApplicationContextRunner contextRunner() {
+        new WebApplicationContextRunner().withUserConfiguration(AssetPipelineAutoConfiguration)
+    }
+
+    void 'the filter that serves the assets is registered'() {
+        expect:
+        contextRunner().run { context ->
+            FilterRegistrationBean registration = context.getBean(FilterRegistrationBean)
+            assert registration.urlPatterns.toList() == ['/assets/*']
+            // built without a manifest, so what serves an asset is what compiles it as it is asked for
+            assert registration.filter instanceof AssetPipelineDevFilter
+        }
+    }
+
+    void 'an application that does not want the filter says so'() {
+        expect: 'a library on the class path is not the same as a library that was asked for'
+        contextRunner().withPropertyValues('assets.enabled=false').run { context ->
+            assert context.getBeanNamesForType(FilterRegistrationBean).length == 0
+        }
+    }
+
+    void 'an application that scans the configuration itself can still decline the filter'() {
+        given: 'the readme told applications to scan this package long before there was a switch'
+        WebApplicationContextRunner runner = new WebApplicationContextRunner()
+                .withUserConfiguration(AssetPipelineService)
+                .withConfiguration(AutoConfigurations.of(AssetPipelineAutoConfiguration))
+                .withPropertyValues('assets.enabled=false')
+
+        expect: 'the switch reaches the configuration that defines the filter, not only the one that imports it'
+        runner.run { context ->
+            assert context.getBeanNamesForType(FilterRegistrationBean).length == 0
+        }
+    }
+
+    void 'an application already scanning the configuration ends up with one filter, not two'() {
+        given: 'what the readme has told applications to do since before there was an auto-configuration'
+        WebApplicationContextRunner runner = new WebApplicationContextRunner()
+                .withUserConfiguration(AssetPipelineService)
+                .withConfiguration(AutoConfigurations.of(AssetPipelineAutoConfiguration))
+
+        // Not a test of the backoff: a scanned configuration class is dropped from the
+        // auto-configuration's import before any condition is asked, so this holds with the
+        // condition removed. The specification below is the one that covers the condition.
+        expect: 'one definition of the filter, whichever of the two paths registered it, and a context that started'
+        runner.run { context ->
+            assert !context.startupFailure
+            assert context.getBeanNamesForType(FilterRegistrationBean).length == 1
+        }
+    }
+
+    void 'an application that registers the filter itself keeps its own'() {
+        given:
+        FilterRegistrationBean ownRegistration = new FilterRegistrationBean()
+
+        expect:
+        contextRunner()
+                .withBean('assetPipelineFilterBean', FilterRegistrationBean, () -> ownRegistration)
+                .run { context ->
+                    assert context.getBean(FilterRegistrationBean).is(ownRegistration)
+                }
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,10 @@ protobufVersion=3.25.9
 rhinoVersion=1.9.1
 servletApiVersion=6.1.0
 slf4jVersion=2.0.18
-# Spock for the Gradle-side (Groovy 4) modules; Grails modules get Spock from grails-bom (2.4-groovy-5.0)
+# Spock for the Gradle-side (Groovy 4) modules
 spockVersion=2.4-groovy-4.0
+# Spock for the modules compiled against Groovy 5; the Grails plugin gets its own from grails-bom
+spock5Version=2.4-groovy-5.0
 springVersion=7.0.8
 springBootVersion=4.1.0
 webjarsLocatorVersion=0.59


### PR DESCRIPTION
Split out of #472 at jdaugherty's request: these changes are Grails-free and should not be held on the plugin discussion.

Lets a Spring Boot application serve what the pipeline compiled without writing the configuration itself. The filter `AssetPipelineService` already declared becomes an auto-configuration, which every application adding this library previously had to `@Import` by hand.

- The manifest an application ships is read where it is, and the filter serves the digest-named files beside it; an application built without one gets the development filter, which compiles an asset as it is asked for.
- An application that declares `AssetPipelineService` itself keeps its own.
- An application that has the library on its class path without wanting the filter sets `assets.enabled=false`.
- `AssetPipelineService` reads the manifest through the `ResourceLoader` it is injected with rather than pulling the context back out of the servlet context — the same context, available before a servlet container is, and testable.

Six specs, all passing, and a full `./gradlew build` is green. `gradle.properties` gains only `spock5Version`, which this module's test wiring needs; the Grails version pin that #472 carries is not here.
